### PR TITLE
XIVY-3424 remove cached files on remote during sync

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,8 @@ pipeline {
         script {
           maven cmd: 'clean verify'
           deployP2Repo srcDir: 'designer.project.maven.p2/target/repository/',
-                                 destDir: 'features/mavenizer/nightly'
+                       destDir: 'features/mavenizer/nightly',
+                       args: '--delete'
         }
         archiveArtifacts 'designer.project.maven.p2/target/*.zip'
       }


### PR DESCRIPTION
- remove 'p2.ready' and 'artifacts.xml' during deployment
in order to avoid unpredicted artifact listings.